### PR TITLE
feat: inject a real fault

### DIFF
--- a/hooking.c
+++ b/hooking.c
@@ -21,14 +21,16 @@ struct cfg_failures *smash_failures;
 int
 smash_failure(void)
 {
-	int buf, world, recv = 0;
+	int buf, world;
 	MPI_Status status;
+	size_t recv = 0;
 
 	MPI_Comm_size(MPI_COMM_WORLD, &world);
 
-	while (recv < world - 1)
+	while (recv != world - smash_failures->size) {
 		MPI_Recv(&buf, 1, MPI_INT, MPI_ANY_SOURCE, 0xdead, MPI_COMM_WORLD, &status);
-	MPI_Finalize();
+		recv++;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The failed processes wait for `world_size - nb_failed_processes` messages with `0xdead` tag to be able to quit and **not failed** processes send this tag to failed processes upon `MPI_Finalize()`. After `smash_failure` returns, it executes `MPI_Finalize()`.